### PR TITLE
Run GraphQL validation as part of the Studio

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@graphiql/toolkit": "0.8.0"
   },
   "devDependencies": {
+    "graphql": "16.6.0",
     "@edgeandnode/components": "^24.4.2",
     "@edgeandnode/eslint-config": "^1.1.0",
     "@emotion/react": ">=11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,7 @@ specifiers:
   esbuild-jest: ^0.5.0
   eslint: ^8.31.0
   eslint-plugin-testing-library: ^5.9.1
+  graphql: 16.6.0
   jest: ^29.3.1
   postcss-nesting: ^10.2.0
   prettier: ^2.8.2
@@ -30,9 +31,9 @@ specifiers:
   vite: ~3.0.7
 
 dependencies:
-  '@graphiql/plugin-explorer': 0.1.12_stssb3vnmyq4bz3xx5bapkdbnm
-  '@graphiql/react': 0.15.0_stssb3vnmyq4bz3xx5bapkdbnm
-  '@graphiql/toolkit': 0.8.0_@types+node@18.11.18
+  '@graphiql/plugin-explorer': 0.1.12_7fmdjgkgquejxjecemaf24t3ku
+  '@graphiql/react': 0.15.0_7fmdjgkgquejxjecemaf24t3ku
+  '@graphiql/toolkit': 0.8.0_ykzowzmb7rcumunkscnbisnkom
 
 devDependencies:
   '@edgeandnode/components': 24.4.2_byxzncqc3sk5z6thaokbtrbebq
@@ -50,6 +51,7 @@ devDependencies:
   esbuild-jest: 0.5.0_esbuild@0.16.16
   eslint: 8.31.0
   eslint-plugin-testing-library: 5.9.1_iukboom6ndih5an6iafl45j2fe
+  graphql: 16.6.0
   jest: 29.3.1_@types+node@18.11.18
   postcss-nesting: 10.2.0_postcss@8.4.21
   prettier: 2.8.2
@@ -1652,7 +1654,7 @@ packages:
       react-dom: 18.2.0_react@18.2.0
     dev: true
 
-  /@graphiql/plugin-explorer/0.1.12_stssb3vnmyq4bz3xx5bapkdbnm:
+  /@graphiql/plugin-explorer/0.1.12_7fmdjgkgquejxjecemaf24t3ku:
     resolution: {integrity: sha512-H7YsmXl96QbYo+8tyV7RXhTDzr7q/W34yZXi0ABnxTMx3K0SGFU9fsnfTliM4TpiRm27lysROriWjqvHbOQXYQ==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
@@ -1662,8 +1664,9 @@ packages:
       graphql:
         optional: true
     dependencies:
-      '@graphiql/react': 0.15.0_stssb3vnmyq4bz3xx5bapkdbnm
-      graphiql-explorer: 0.9.0_biqbaboplfbrettd7655fr4n2y
+      '@graphiql/react': 0.15.0_7fmdjgkgquejxjecemaf24t3ku
+      graphiql-explorer: 0.9.0_gdcq4dv6opitr3wbfwyjmanyra
+      graphql: 16.6.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     transitivePeerDependencies:
@@ -1674,7 +1677,7 @@ packages:
       - react-is
     dev: false
 
-  /@graphiql/react/0.15.0_stssb3vnmyq4bz3xx5bapkdbnm:
+  /@graphiql/react/0.15.0_7fmdjgkgquejxjecemaf24t3ku:
     resolution: {integrity: sha512-kJqkdf6d4Cck05Wt5yCDZXWfs7HZgcpuoWq/v8nOa698qVaNMM3qdG4CpRsZEexku0DSSJzWWuanxd5x+sRcFg==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
@@ -1684,7 +1687,7 @@ packages:
       graphql:
         optional: true
     dependencies:
-      '@graphiql/toolkit': 0.8.0_@types+node@18.11.18
+      '@graphiql/toolkit': 0.8.0_ykzowzmb7rcumunkscnbisnkom
       '@reach/combobox': 0.17.0_biqbaboplfbrettd7655fr4n2y
       '@reach/dialog': 0.17.0_ib3m5ricvtkl2cll7qpr2f6lvq
       '@reach/listbox': 0.17.0_biqbaboplfbrettd7655fr4n2y
@@ -1692,9 +1695,10 @@ packages:
       '@reach/tooltip': 0.17.0_biqbaboplfbrettd7655fr4n2y
       '@reach/visually-hidden': 0.17.0_biqbaboplfbrettd7655fr4n2y
       codemirror: 5.65.8
-      codemirror-graphql: 2.0.2_eohaxr5dvewnzputngngeqrer4
+      codemirror-graphql: 2.0.2_gy53rcbkf6ix5on45ngnmopswy
       copy-to-clipboard: 3.3.2
-      graphql-language-service: 5.1.0
+      graphql: 16.6.0
+      graphql-language-service: 5.1.0_graphql@16.6.0
       markdown-it: 12.3.2
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -1707,7 +1711,7 @@ packages:
       - react-is
     dev: false
 
-  /@graphiql/toolkit/0.8.0_@types+node@18.11.18:
+  /@graphiql/toolkit/0.8.0_ykzowzmb7rcumunkscnbisnkom:
     resolution: {integrity: sha512-DbMFhEKejpPzB6k8W3Mj+Rl8geXiw49USDF9Wdi06EEk1XLVh1iebDqveYY+4lViITsV4+BeGikxlqi8umfP4g==}
     peerDependencies:
       graphql: ^15.5.0 || ^16.0.0
@@ -1719,6 +1723,7 @@ packages:
         optional: true
     dependencies:
       '@n1ru4l/push-pull-async-iterable-iterator': 3.2.0
+      graphql: 16.6.0
       meros: 1.2.0_@types+node@18.11.18
     transitivePeerDependencies:
       - '@types/node'
@@ -4490,7 +4495,7 @@ packages:
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
     dev: true
 
-  /codemirror-graphql/2.0.2_eohaxr5dvewnzputngngeqrer4:
+  /codemirror-graphql/2.0.2_gy53rcbkf6ix5on45ngnmopswy:
     resolution: {integrity: sha512-9c1cItR+8lG7thmTnDDQ3zI8YesNKiFCp2BnLFkYWCtdhSSuCUHebU/Vurew6ayyUl8MBCldNx3Ev66QAWM5Kw==}
     peerDependencies:
       '@codemirror/language': 6.0.0
@@ -4502,7 +4507,8 @@ packages:
     dependencies:
       '@codemirror/language': 6.0.0
       codemirror: 5.65.8
-      graphql-language-service: 5.0.6
+      graphql: 16.6.0
+      graphql-language-service: 5.0.6_graphql@16.6.0
     dev: false
 
   /codemirror/5.65.8:
@@ -6305,7 +6311,7 @@ packages:
     resolution: {integrity: sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==}
     dev: true
 
-  /graphiql-explorer/0.9.0_biqbaboplfbrettd7655fr4n2y:
+  /graphiql-explorer/0.9.0_gdcq4dv6opitr3wbfwyjmanyra:
     resolution: {integrity: sha512-fZC/wsuatqiQDO2otchxriFO0LaWIo/ovF/CQJ1yOudmY0P7pzDiP+l9CEHUiWbizk3e99x6DQG4XG1VxA+d6A==}
     peerDependencies:
       graphql: ^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0
@@ -6315,11 +6321,12 @@ packages:
       graphql:
         optional: true
     dependencies:
+      graphql: 16.6.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     dev: false
 
-  /graphql-language-service/5.0.6:
+  /graphql-language-service/5.0.6_graphql@16.6.0:
     resolution: {integrity: sha512-FjE23aTy45Lr5metxCv3ZgSKEZOzN7ERR+OFC1isV5mHxI0Ob8XxayLTYjQKrs8b3kOpvgTYmSmu6AyXOzYslg==}
     hasBin: true
     peerDependencies:
@@ -6328,11 +6335,12 @@ packages:
       graphql:
         optional: true
     dependencies:
+      graphql: 16.6.0
       nullthrows: 1.1.1
       vscode-languageserver-types: 3.17.2
     dev: false
 
-  /graphql-language-service/5.1.0:
+  /graphql-language-service/5.1.0_graphql@16.6.0:
     resolution: {integrity: sha512-APffigZ/l2me6soek+Yq5Us3HBwmfw4vns4QoqsTePXkK3knVO8rn0uAC6PmTyglb1pmFFPbYaRIzW4wmcnnGQ==}
     hasBin: true
     peerDependencies:
@@ -6341,6 +6349,7 @@ packages:
       graphql:
         optional: true
     dependencies:
+      graphql: 16.6.0
       nullthrows: 1.1.1
       vscode-languageserver-types: 3.17.2
     dev: false
@@ -6361,7 +6370,6 @@ packages:
   /graphql/16.6.0:
     resolution: {integrity: sha512-KPIBPDlW7NxrbT/eh4qPXz5FiFdL5UbaA0XUNz2Rp3Z3hqBSkbj0GVjwFDztsWVauZUWsbKHgMg++sk8UX0bkw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    dev: true
 
   /hardhat-watcher/2.5.0_hardhat@2.10.2:
     resolution: {integrity: sha512-Su2qcSMIo2YO2PrmJ0/tdkf+6pSt8zf9+4URR5edMVti6+ShI8T3xhPrwugdyTOFuyj8lKHrcTZNKUFYowYiyA==}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,7 +66,7 @@ function extendFetcherWithValidations(schema: GraphQLSchema | null, fetcher: Fet
           data: null,
           extensions: {
             warning:
-              'The Graph will soon start returning validation errors for GraphQL queries. Please fix the errors in your queries. For more information: LINK_HERE',
+              'The Graph will soon start returning validation errors for GraphQL queries. Please fix the errors in your queries. For more information: https://thegraph.com/docs/en/release-notes/graphql-validations-migration-guide',
           },
           errors: validationErrors,
         }


### PR DESCRIPTION
- `graphql` was added as `devDependency` only, because I saw `@edgeandnode/common` brings it at runtime.
- `parse` + `validate` are running now on the browser, before running the actual query over the network, and return the errors, the same way as it would be when validations will we enabled on `graph-node`. 


## TODO
- [x] Review 
- [x] Add the actual link